### PR TITLE
cli: add splitArguments functionality 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,9 @@ sparse merge # merges bottom stack if mergeable and there is no block and update
 sparse update # updates the stack `rebase --update-refs`
 sparse switch [1..n|<stack_name>] # by default switches the last stack or switches to given stack_name
 ```
+
+## Interactions with git
+
+Sparse uses git to handle all git related operations so `git` must be present
+in `PATH`. Please follow the instructions on [git-scm](https://git-scm.com/) to
+install it.

--- a/README.md
+++ b/README.md
@@ -9,12 +9,11 @@ available in your `path` to make `sparse` work.
 ## Using sparse
 
 ```
-sparse check # dumps the status information for the current stack and the PRs
+sparse check
+sparse feature --help
+sparse slice --help
 sparse submit # submits the pr for the stack so far or updates the existing PRs for stack
-sparse new [<dev> [<target:-main>]] # creates a new stack if no argument provided and there is already a active stack, or creates a new stack if name provided
-sparse merge # merges bottom stack if mergeable and there is no block and updates the stack
-sparse update # updates the stack `rebase --update-refs`
-sparse switch [1..n|<stack_name>] # by default switches the last stack or switches to given stack_name
+sparse config # alias for git config/stackpr settings for the repo
 ```
 
 ## Interactions with git
@@ -22,3 +21,69 @@ sparse switch [1..n|<stack_name>] # by default switches the last stack or switch
 Sparse uses git to handle all git related operations so `git` must be present
 in `PATH`. Please follow the instructions on [git-scm](https://git-scm.com/) to
 install it.
+
+### Stacking with git branches
+
+Sparse creates a new branch for every stack in a feature. In stack layout below
+`create-fancy-button` branch is the main feature branch that we are currently working on.
+The stacks we are building, we call them `slices`, are created using nested branching
+strategy.
+
+```
+sparse/create-fancy-button                                          ==> feature
+`-- sparse/<config.email>/create-fancy-button/(n|<slice>)           ==> stack
+    `-- sparse/<config.email>/create-fancy-button/(n+1|<slice>)     ==> stack
+        `-- sparse/<config.email>/create-fancy-button/(n+2|<slice>) ==> stack
+```
+
+You can give a name for your each `slice` under main `feature` to point them easily
+when you need to refactor them. You can of course skip naming your slices, in that
+case they will have an incrementing number as a name.
+
+#### New feature development workflow
+
+To start a new feature, developer must use `sparse feature` command,
+see details of the command below:
+
+```
+sparse feature [ options ] <feature_name> [<slice_name>]
+    args:
+        <feature_name>: name of the feature to be created. If a feature with the
+                        same name exists, sparse simply switches to that feature.
+        <slice_name>:   name of the first slice in newly created feature. This
+                        argument is ignored if the feature already exists.
+    options:
+        --help: Shows this help message
+        --to <base_(feature/branch)>: branch or feature to build on top (default: main)
+```
+
+Then do your work as usual using `git`. And you feel like you make enough changes for a single PR, then
+use `sparse submit` command to submit your changes to remote and create PRs for your slices.
+To continue working on the feature with a new slice use `sparse slice` command to create
+new slice.
+
+```
+sparse slice [ options ] [ <slice_name> ]
+    args:
+        <slice_name>:   name of the new slice in the feature. If the slice with
+                        the same name exists, then sparse switches to that slice
+                        If the slice name is not provided, then sparse creates
+                        the slice based on the number of slices currently in the feature.
+    options:
+        --help:   Shows this help message
+        --before: Creates new slice before (current or given) slice
+        --after:  Creates new slice after (current or given) slice
+
+```
+
+Say you got some feedback for your old slices, save what you were doing via `git stash` or
+commit temporarily as usual with `git commit`. Then switch to slice that you want to update
+with `sparse slice <slice_you_want_to_update>`, do your magic, commit your changes then
+submit as usual with `sparse submit` command.
+
+```
+sparse submit [ options ]
+    Creates PRs for slices in the feature
+    options:
+        -d, --draft: creates PRs as drafts if it is supported.
+```

--- a/src/cli/check_command.zig
+++ b/src/cli/check_command.zig
@@ -11,7 +11,7 @@ pub const Options = struct {
         return @constCast("Hello Moto!");
     }
 };
-pub const Args = struct {
+pub const Positionals = struct {
     c: bool = false,
     a: u32 = 5,
     b: u32 = 10,
@@ -21,11 +21,12 @@ pub const Args = struct {
 pub const CheckCommand = struct {
     pub fn run(self: CheckCommand, alloc: Allocator) !u8 {
         _ = self;
-        var args: Args = .{};
-        const cli_args = try std.process.argsAlloc(alloc);
-        defer std.process.argsFree(alloc, cli_args);
+        var positionals: Positionals = .{};
 
-        try command.parseArgs(Args, alloc, &args, cli_args);
+        const args = try std.process.argsAlloc(alloc);
+        defer std.process.argsFree(alloc, args);
+
+        try command.parsePositionals(Positionals, alloc, &positionals, args);
         return 0;
         // check [options] [<branch>]
         // options:

--- a/src/cli/command.zig
+++ b/src/cli/command.zig
@@ -108,7 +108,7 @@ const ArgDeserializer = struct {
     }
 };
 
-pub fn splitCliArgs(alloc: Allocator, cli_args: [][:0]u8) !struct { std.ArrayListUnmanaged([]u8), std.ArrayListUnmanaged([]u8) } {
+pub fn splitArgs(alloc: Allocator, cli_args: [][:0]u8) !struct { std.ArrayListUnmanaged([]u8), std.ArrayListUnmanaged([]u8) } {
     var positionals: std.ArrayListUnmanaged([]u8) = .empty;
     var options: std.ArrayListUnmanaged([]u8) = .empty;
     for (cli_args, 0..) |arg, index| {
@@ -119,7 +119,7 @@ pub fn splitCliArgs(alloc: Allocator, cli_args: [][:0]u8) !struct { std.ArrayLis
     return .{ options, positionals };
 }
 
-pub fn parseArgs(
+pub fn parsePositionals(
     comptime T: type,
     alloc: Allocator,
     dst: *T,
@@ -156,7 +156,7 @@ test "parseArgs example options and args" {
     var args: Args = .{};
     const cli_args = "--f start --target dev after new a b c ddd";
     const iter = std.mem.splitAny(u8, cli_args, " ");
-    try parseArgs(Args, allocator, &args, @constCast(&iter));
+    try parsePositionals(Args, allocator, &args, @constCast(&iter));
     try expectEqual(true, args.start);
     try expectEqual(true, args.after);
     try expectEqual(true, args.options.@"--f");

--- a/src/cli/command.zig
+++ b/src/cli/command.zig
@@ -108,7 +108,9 @@ const ArgDeserializer = struct {
     }
 };
 
-pub fn splitArgs(alloc: Allocator, cli_args: [][:0]u8) !struct { std.ArrayListUnmanaged([]u8), std.ArrayListUnmanaged([]u8) } {
+pub fn splitArgs(alloc: Allocator, cli_args: [][:0]u8, comptime P: anytype, comptime O: anytype) !struct { std.ArrayListUnmanaged([]u8), std.ArrayListUnmanaged([]u8) } {
+    _ = P;
+    _ = O;
     var positionals: std.ArrayListUnmanaged([]u8) = .empty;
     var options: std.ArrayListUnmanaged([]u8) = .empty;
     for (cli_args, 0..) |arg, index| {

--- a/src/cli/command.zig
+++ b/src/cli/command.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const debug = std.debug.print;
 const Allocator = std.mem.Allocator;
 const CheckCommand = @import("check_command.zig").CheckCommand;
 const NewCommand = @import("new_command.zig").NewCommand;
@@ -106,6 +107,17 @@ const ArgDeserializer = struct {
         };
     }
 };
+
+pub fn splitCliArgs(alloc: Allocator, cli_args: [][:0]u8) !struct { std.ArrayListUnmanaged([]u8), std.ArrayListUnmanaged([]u8) } {
+    var positionals: std.ArrayListUnmanaged([]u8) = .empty;
+    var options: std.ArrayListUnmanaged([]u8) = .empty;
+    for (cli_args, 0..) |arg, index| {
+        try positionals.append(alloc, arg);
+        try options.append(alloc, arg);
+        debug("\n{s} {d}\n", .{ arg, index });
+    }
+    return .{ options, positionals };
+}
 
 pub fn parseArgs(
     comptime T: type,

--- a/src/cli/command.zig
+++ b/src/cli/command.zig
@@ -107,13 +107,45 @@ const ArgDeserializer = struct {
         };
     }
 };
+//pub fn getFieldByName(alloc: Allocator, comptime T: anytype, field_name: []const u8) ?struct { [:0]const u8, type } {
+//    var fields_list: std.ArrayListUnmanaged(std.builtin.Type.StructField) = .empty;
+//    const fields = @typeInfo(T).@"struct".fields;
+//    for (fields) |field| {
+//        fields_list.append(alloc, field);
+//        //if (std.mem.eql(u8, field_name, field.name)) {
+//        //  return .{ field.name, field.type };
+//        // }
+//
+//    }
+//    for (fields_list) |elem| {
+//        if (std.mem.eql(u8, elem.name, field_name)) {
+//            std.debug.print("did it work field name equal to my name {s}", field_name);
+//            return .{ elem.name, elem.type };
+//        }
+//    }
+//    //arg is not in positionals nor options
+//    return null;
+//}
+pub fn getFieldByName(opt_fields: []std.builtin.Type.StructField, arg: []u8) bool {
+    inline for (opt_fields) |field| {
+        if (std.mem.eql(u8, field.name, arg)) {
+            return true;
+        }
+    }
+    return false;
+}
 
-pub fn splitArgs(alloc: Allocator, cli_args: [][:0]u8, comptime P: anytype, comptime O: anytype) !struct { std.ArrayListUnmanaged([]u8), std.ArrayListUnmanaged([]u8) } {
+pub fn splitArgs(alloc: Allocator, cli_args: [][:0]u8, comptime P: anytype, O: anytype, opt_fields: []std.builtin.Type.StructField) !struct { std.ArrayListUnmanaged([]u8), std.ArrayListUnmanaged([]u8) } {
     _ = P;
     _ = O;
     var positionals: std.ArrayListUnmanaged([]u8) = .empty;
     var options: std.ArrayListUnmanaged([]u8) = .empty;
     for (cli_args, 0..) |arg, index| {
+        if (std.mem.startsWith(u8, arg, "--")) {
+            if (getFieldByName(opt_fields, arg)) {
+                debug("buldum", .{});
+            }
+        }
         try positionals.append(alloc, arg);
         try options.append(alloc, arg);
         debug("\n{s} {d}\n", .{ arg, index });

--- a/src/cli/new_command.zig
+++ b/src/cli/new_command.zig
@@ -5,6 +5,7 @@ const log = @import("std").log.scoped(".new_command");
 
 pub const Options = struct {
     @"--orphan": bool = false,
+    @"--bele": usize = 10,
     //fields: []std.builtin.Type.StructField = undefined,
     pub fn help(self: Options) ![]u8 {
         return self._help();
@@ -42,16 +43,19 @@ pub const NewCommand = struct {
         _ = self;
         comptime var option_fields = getFields(Options);
         var positionals: Positionals = .{};
-        var options: Options = .{};
+        // TODO: make it var when parseOptions is implemented
+        const options: Options = .{};
+        _ = options;
         const args = try std.process.argsAlloc(alloc);
         defer std.process.argsFree(alloc, args);
 
-        var cli_struct = try command.splitArgs(alloc, args, Positionals, &options, option_fields);
-        defer cli_struct.@"0".deinit(alloc);
-        defer cli_struct.@"1".deinit(alloc);
+        var cli_options, var cli_positionals = try command.splitArgs(alloc, args, option_fields);
+        defer cli_positionals.deinit(alloc);
+        defer cli_options.deinit(alloc);
 
-        std.debug.print("{any}", .{cli_struct});
-
+        for (cli_options.items) |item| {
+            std.debug.print("item:{s}\n", .{item});
+        }
         try command.parsePositionals(Positionals, alloc, &positionals, args);
         if (positionals.advanced) |details| {
             std.debug.print("{s} {s}\n", .{ details.branch[0], details.target.?[0] });

--- a/src/cli/new_command.zig
+++ b/src/cli/new_command.zig
@@ -38,7 +38,7 @@ pub const NewCommand = struct {
         const args = try std.process.argsAlloc(alloc);
         defer std.process.argsFree(alloc, args);
 
-        var cli_struct = try command.splitArgs(alloc, args);
+        var cli_struct = try command.splitArgs(alloc, args, Positionals, Options);
         defer cli_struct.@"0".deinit(alloc);
         defer cli_struct.@"1".deinit(alloc);
 

--- a/src/cli/new_command.zig
+++ b/src/cli/new_command.zig
@@ -17,7 +17,7 @@ pub const Options = struct {
     }
 };
 
-pub const Args = struct {
+pub const Positionals = struct {
     advanced: ?struct {
         branch: [1][]u8 = undefined,
         target: ?[1][]u8 = .{@constCast("main")},
@@ -31,18 +31,21 @@ pub const NewCommand = struct {
     //  -h, --help
     pub fn run(self: NewCommand, alloc: Allocator) !u8 {
         _ = self;
-        var args: Args = .{};
+        var positionals: Positionals = .{};
         const options: Options = .{};
         _ = options;
 
-        const cli_args = try std.process.argsAlloc(alloc);
-        defer std.process.argsFree(alloc, cli_args);
-        var cli_struct = try command.splitCliArgs(alloc, cli_args);
+        const args = try std.process.argsAlloc(alloc);
+        defer std.process.argsFree(alloc, args);
+
+        var cli_struct = try command.splitArgs(alloc, args);
         defer cli_struct.@"0".deinit(alloc);
         defer cli_struct.@"1".deinit(alloc);
+
         std.debug.print("{any}", .{cli_struct});
-        try command.parseArgs(Args, alloc, &args, cli_args);
-        if (args.advanced) |details| {
+
+        try command.parsePositionals(Positionals, alloc, &positionals, args);
+        if (positionals.advanced) |details| {
             std.debug.print("{s} {s}\n", .{ details.branch[0], details.target.?[0] });
         }
         return 0;

--- a/src/cli/new_command.zig
+++ b/src/cli/new_command.zig
@@ -32,9 +32,15 @@ pub const NewCommand = struct {
     pub fn run(self: NewCommand, alloc: Allocator) !u8 {
         _ = self;
         var args: Args = .{};
+        const options: Options = .{};
+        _ = options;
 
         const cli_args = try std.process.argsAlloc(alloc);
         defer std.process.argsFree(alloc, cli_args);
+        var cli_struct = try command.splitCliArgs(alloc, cli_args);
+        defer cli_struct.@"0".deinit(alloc);
+        defer cli_struct.@"1".deinit(alloc);
+        std.debug.print("{any}", .{cli_struct});
         try command.parseArgs(Args, alloc, &args, cli_args);
         if (args.advanced) |details| {
             std.debug.print("{s} {s}\n", .{ details.branch[0], details.target.?[0] });


### PR DESCRIPTION
This PR is aiming to splitting terminal input  from cli to positionals and options somehow magical or stupid dynamically(comptime, runtime) instead of using hardcoded field names. It was a small step for humanity yet was a big and fun for me 
