### PR TITLE
cli: handle functions in options

### DIFF
--- a/src/cli/feature_command.zig
+++ b/src/cli/feature_command.zig
@@ -12,20 +12,34 @@ const Params = struct {
         @"-h": *const fn () void = Options.help,
 
         pub fn help() void {
-            std.debug.print("this is an help text\n", .{});
+            std.io.getStdOut().writer().print(
+                \\ sparse feature [ options ] <feature_name> [<slice_name>]
+                \\ args:
+                \\     <feature_name>: name of the feature to be created. If a feature with the
+                \\                     same name exists, sparse simply switches to that feature.
+                \\     <slice_name>:   name of the first slice in newly created feature. This
+                \\                     argument is ignored if the feature already exists.
+                \\ options:
+                \\     --help: Shows this help message
+                \\     --to <base_(feature/branch)>: branch or feature to build on top (default: main)
+                \\
+            , .{}) catch return;
         }
     } = .{},
 };
+
+///
+/// sparse feature [ options ] <feature_name> [<slice_name>]
+/// args:
+///     <feature_name>: name of the feature to be created. If a feature with the
+///                     same name exists, sparse simply switches to that feature.
+///     <slice_name>:   name of the first slice in newly created feature. This
+///                     argument is ignored if the feature already exists.
+/// options:
+///     --help: Shows this help message
+///     --to <base_(feature/branch)>: branch or feature to build on top (default: main)
+///
 pub const FeatureCommand = struct {
-    /// sparse feature [ options ] <feature_name> [<slice_name>]
-    /// args:
-    ///     <feature_name>: name of the feature to be created. If a feature with the
-    ///                     same name exists, sparse simply switches to that feature.
-    ///     <slice_name>:   name of the first slice in newly created feature. This
-    ///                     argument is ignored if the feature already exists.
-    /// options:
-    ///     --help: Shows this help message
-    ///     --to <base_(feature/branch)>: branch or feature to build on top (default: main)
     pub fn run(self: FeatureCommand, alloc: Allocator) !u8 {
         _ = self;
         var params = Params{ .feature_name = undefined };

--- a/src/cli/feature_command.zig
+++ b/src/cli/feature_command.zig
@@ -1,13 +1,19 @@
 const std = @import("std");
 const Allocator = @import("std").mem.Allocator;
 const log = @import("std").log.scoped(.feature_command);
-//const FeatureCommand = @This();
 
 const Params = struct {
     feature_name: [1][]u8,
     slice_name: ?[1][]u8 = null,
     _options: struct {
+        const Options = @This();
         @"--to": []const u8 = "main",
+        @"--help": *const fn () void = Options.help,
+        @"-h": *const fn () void = Options.help,
+
+        pub fn help() void {
+            std.debug.print("this is an help text\n", .{});
+        }
     } = .{},
 };
 pub const FeatureCommand = struct {
@@ -27,12 +33,16 @@ pub const FeatureCommand = struct {
         defer std.process.argsFree(alloc, args);
         log.debug("got cli arguments: {s}", .{args});
 
-        const cli_positionals = try command.parseOptions(
+        const cli_positionals = command.parseOptions(
             @TypeOf(params._options),
             alloc,
             &params._options,
             args,
-        );
+        ) catch |err| switch (err) {
+            command.Error.OptionHandledAlready => return 0,
+            else => return err,
+        };
+
         defer alloc.free(cli_positionals);
         try command.parsePositionals(
             Params,


### PR DESCRIPTION
Using function pointers to handle functions for options. This also resolves #19