### PR TITLE
Start using libgit2 as backend and implement slice module

### DIFF
--- a/src/cli/feature_command.zig
+++ b/src/cli/feature_command.zig
@@ -67,20 +67,31 @@ pub const FeatureCommand = struct {
                 params._options.@"--to",
             },
         );
-        Sparse.feature(
-            params.feature_name[0],
-            if (params.slice_name) |s| s[0] else null,
-            params._options.@"--to",
-        ) catch |err| switch (err) {
-            else => {
-                log.err("error: {any}", .{err});
-                return 1;
-            },
-        };
+
+        try LibGit.init();
+        defer LibGit.shutdown() catch @panic("Oops something weird is cooking...");
+        const repo = try LibGit.GitRepository.open();
+        defer repo.free();
+
+        try Sparse.Slice.getAllSlicesWith(.{
+            .allocator = alloc,
+            .repo = repo,
+        });
+        // Sparse.feature(
+        //     params.feature_name[0],
+        //     if (params.slice_name) |s| s[0] else null,
+        //     params._options.@"--to",
+        // ) catch |err| switch (err) {
+        //     else => {
+        //         log.err("error: {any}", .{err});
+        //         return 1;
+        //     },
+        // };
 
         return 0;
     }
 };
 
 const Sparse = @import("sparse_lib").Sparse;
+const LibGit = @import("sparse_lib").LibGit;
 const command = @import("command.zig");

--- a/src/cli/feature_command.zig
+++ b/src/cli/feature_command.zig
@@ -68,30 +68,20 @@ pub const FeatureCommand = struct {
             },
         );
 
-        try LibGit.init();
-        defer LibGit.shutdown() catch @panic("Oops something weird is cooking...");
-        const repo = try LibGit.GitRepository.open();
-        defer repo.free();
-
-        try Sparse.Slice.getAllSlicesWith(.{
-            .allocator = alloc,
-            .repo = repo,
-        });
-        // Sparse.feature(
-        //     params.feature_name[0],
-        //     if (params.slice_name) |s| s[0] else null,
-        //     params._options.@"--to",
-        // ) catch |err| switch (err) {
-        //     else => {
-        //         log.err("error: {any}", .{err});
-        //         return 1;
-        //     },
-        // };
+        Sparse.feature(
+            params.feature_name[0],
+            if (params.slice_name) |s| s[0] else null,
+            params._options.@"--to",
+        ) catch |err| switch (err) {
+            else => {
+                log.err("error: {any}", .{err});
+                return 1;
+            },
+        };
 
         return 0;
     }
 };
 
 const Sparse = @import("sparse_lib").Sparse;
-const LibGit = @import("sparse_lib").LibGit;
 const command = @import("command.zig");

--- a/src/lib/libgit2/libgit2.zig
+++ b/src/lib/libgit2/libgit2.zig
@@ -25,3 +25,6 @@ pub const GitWorktreeAddOptions = @import("worktree.zig").GitWorktreeAddOptions;
 pub const GitBranchType = @import("branch.zig").GitBranchType;
 pub const GitBranch = @import("branch.zig").GitBranch;
 pub const GitRevSpec = @import("revspec.zig").GitRevSpec;
+pub const GitReflog = @import("reflog.zig").GitReflog;
+pub const GitReflogEntry = @import("reflog.zig").GitReflogEntry;
+pub const GitSignature = @import("signature.zig").GitSignature;

--- a/src/lib/libgit2/reflog.zig
+++ b/src/lib/libgit2/reflog.zig
@@ -54,4 +54,3 @@ const GitError = @import("error.zig").GitError;
 const GitRepository = @import("repository.zig").GitRepository;
 const GitString = @import("types.zig").GitString;
 const GitSignature = @import("signature.zig").GitSignature;
-//const cStringToGitString = @import("types.zig").cStringToGitString;

--- a/src/lib/libgit2/reflog.zig
+++ b/src/lib/libgit2/reflog.zig
@@ -1,0 +1,57 @@
+const c = @import("c.zig").c;
+pub const GitReflogEntry = struct {
+    value: ?*c.git_reflog_entry = null,
+
+    pub fn committer(self: GitReflogEntry) GitSignature {
+        var signature: GitSignature = .{ .value = .{} };
+        const _committer = c.git_reflog_entry_committer(self.value);
+        if (_committer) |_c| {
+            signature.value = _c.*;
+        } else {
+            signature.value = null;
+        }
+
+        return signature;
+    }
+};
+
+pub const GitReflog = struct {
+    value: ?*c.git_reflog = null,
+
+    pub fn read(repo: GitRepository, name: GitString) !GitReflog {
+        var reflog = GitReflog{};
+
+        const res: c_int = c.git_reflog_read(&reflog.value, repo.value, @ptrCast(name));
+        if (res != 0) {
+            return GitError.UNEXPECTED_ERROR;
+        }
+        return reflog;
+    }
+
+    pub fn entrycount(self: GitReflog) usize {
+        return c.git_reflog_entrycount(self.value);
+    }
+
+    /// https://libgit2.org/docs/reference/main/reflog/git_reflog_entry_byindex.html
+    pub fn entryByIndex(self: GitReflog, index: usize) ?GitReflogEntry {
+        const reflog_entry = GitReflogEntry{
+            .value = @constCast(c.git_reflog_entry_byindex(self.value, index)),
+        };
+
+        if (reflog_entry.value) |_| {
+            return reflog_entry;
+        }
+
+        return null;
+    }
+
+    pub fn free(self: GitReflog) void {
+        c.git_reflog_free(self.value);
+    }
+};
+
+const GitError = @import("error.zig").GitError;
+const GitRepository = @import("repository.zig").GitRepository;
+const GitString = @import("types.zig").GitString;
+const GitSignature = @import("signature.zig").GitSignature;
+//const cStringToGitString = @import("types.zig").cStringToGitString;

--- a/src/lib/libgit2/signature.zig
+++ b/src/lib/libgit2/signature.zig
@@ -1,0 +1,13 @@
+const c = @import("c.zig").c;
+
+pub const GitSignature = struct {
+    value: ?c.git_signature = null,
+
+    pub fn free(self: GitSignature) void {
+        c.git_signature_free(self.value);
+    }
+};
+
+const GitError = @import("error.zig").GitError;
+const GitRepository = @import("repository.zig").GitRepository;
+const GitString = @import("types.zig").GitString;

--- a/src/lib/slice.zig
+++ b/src/lib/slice.zig
@@ -1,0 +1,48 @@
+const std = @import("std");
+const log = std.log.scoped(.slice);
+const Allocator = std.mem.Allocator;
+
+///
+/// Returns all slices available with given constraints.
+///
+/// options:
+/// .inFeature(?[]const u8): feature to search slices in, if it is null
+///  function returns all slices ignoring which feature they are in.
+pub fn getAllSlicesWith(o: struct {
+    allocator: Allocator,
+    repo: LibGit.GitRepository,
+    inFeature: ?[]const u8 = null,
+}) !void {
+    var glob: []u8 = undefined;
+    if (o.inFeature) |f| {
+        glob = try std.fmt.allocPrint(
+            o.allocator,
+            "refs/heads/sparse/havadartalha@gmail.com/{s}/*",
+            .{f},
+        );
+    } else {
+        glob = try std.fmt.allocPrint(
+            o.allocator,
+            "refs/heads/sparse/havadartalha@gmail.com/*",
+            .{},
+        );
+    }
+    defer o.allocator.free(glob);
+
+    //std.fmt.allocPrint(o.allocator, comptime fmt: []const u8, args: anytype)
+    var ref_iter = try LibGit.GitReferenceIterator.fromGlob(glob, o.repo);
+    defer ref_iter.free();
+    while (try ref_iter.next()) |ref| {
+        const reflog = try LibGit.GitReflog.read(o.repo, ref.name());
+        defer reflog.free();
+        const last_entry = reflog.entryByIndex(reflog.entrycount() - 1).?;
+        const committer = last_entry.committer().value.?;
+        log.debug(
+            "getAllSlicesWith:: ref.name: {s} entrycount: {d} committer:{s} time:{d}",
+            .{ ref.name(), reflog.entrycount(), committer.email, committer.when.time },
+        );
+    }
+}
+const Slice = struct {};
+
+const LibGit = @import("libgit2/libgit2.zig");

--- a/src/lib/sparse.zig
+++ b/src/lib/sparse.zig
@@ -16,6 +16,8 @@ pub fn feature(
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer std.debug.assert(gpa.deinit() == .ok);
     const allocator = gpa.allocator();
+    try LibGit.init();
+    defer LibGit.shutdown() catch @panic("Oops: couldn't shutdown libgit2, something weird is cooking...");
 
     log.debug("feature:: feature_name:{s} slice_name:{s} target:{s}", .{
         feature_name,
@@ -179,20 +181,6 @@ fn jump(o: struct {
         .create = o.create,
         .slice_name = o.slice,
     });
-    // const run_result = try Git.@"switch"(.{
-    //     .allocator = o.allocator,
-    //     .args = &.{
-    //         if (o.create) "-c" else "",
-    //         o.to.name[0],
-    //         if (o.to.start_point) |s| s else "",
-    //     },
-    // });
-    // defer o.allocator.free(run_result.stderr);
-    // defer o.allocator.free(run_result.stdout);
-
-    // if (run_result.term.Exited != 0) {
-    //     return Error.UNABLE_TO_SWITCH_BRANCHES;
-    // }
 }
 
 const constants = @import("constants.zig");
@@ -202,4 +190,4 @@ const GitBranch = LibGit.GitBranch;
 const GitBranchType = LibGit.GitBranchType;
 const Git = @import("system/Git.zig");
 const Feature = @import("Feature.zig");
-pub const Slice = @import("slice.zig");
+const Slice = @import("slice.zig");

--- a/src/lib/sparse.zig
+++ b/src/lib/sparse.zig
@@ -8,10 +8,6 @@ pub const Error = error{
     CORRUPTED_FEATURE,
 };
 
-const Slice = struct {
-    name: [1]GitString,
-};
-
 pub fn feature(
     feature_name: []const u8,
     slice_name: ?[]const u8,
@@ -206,3 +202,4 @@ const GitBranch = LibGit.GitBranch;
 const GitBranchType = LibGit.GitBranchType;
 const Git = @import("system/Git.zig");
 const Feature = @import("Feature.zig");
+pub const Slice = @import("slice.zig");

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,7 +1,7 @@
 //! By convention, root.zig is the root source file when making a library. If
 //! you are making an executable, the convention is to delete this file and
 //! start with main.zig instead.
-const LibGit = @import("lib/libgit2/libgit2.zig");
+pub const LibGit = @import("lib/libgit2/libgit2.zig");
 const std = @import("std");
 
 pub fn examples() !void {

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,7 +1,7 @@
 //! By convention, root.zig is the root source file when making a library. If
 //! you are making an executable, the convention is to delete this file and
 //! start with main.zig instead.
-pub const LibGit = @import("lib/libgit2/libgit2.zig");
+const LibGit = @import("lib/libgit2/libgit2.zig");
 const std = @import("std");
 
 pub fn examples() !void {


### PR DESCRIPTION
We are using reflogs to determine which branch is created first so fetching reflogs
for the references is an everyday task to us so it makes things easier for us if we
pack reflogs together with GitReference.

We can change it to be lazy loaded afterwards if we see significant performance drop.

Created `slices.zig` which implements a function `getAllSlicesWith`
which is being used in Feature. We also changed the way we detect the
first slice. Now we use the first reflog entry of the slice to determine
the order of creation for slices.