### PR TITLE
sparse: fix feature jumping when there is no ref

### DIFF
--- a/src/lib/Feature.zig
+++ b/src/lib/Feature.zig
@@ -48,7 +48,11 @@ pub fn free(self: *Feature, allocator: Allocator) void {
 pub fn activeFeature(o: struct {
     allocator: Allocator,
 }) !?Feature {
-    const head_ref = try Git.getHeadRef(.{ .allocator = o.allocator });
+    log.debug("activeFeature::", .{});
+    const head_ref = Git.getHeadRef(.{ .allocator = o.allocator }) catch |err| switch (err) {
+        error.BACKEND_UNABLE_TO_DETERMINE_CURRENT_BRANCH => return null,
+        else => return err,
+    };
     defer head_ref.free(o.allocator);
 
     log.debug(
@@ -83,9 +87,10 @@ pub fn findFeatureByName(o: struct {
     allocator: Allocator,
     feature_name: []const u8,
 }) !?Feature {
+    log.debug("findFeatureByName::", .{});
     // get all branch refs using git
     var branch_refs = try Git.getBranchRefs(.{
-        .allocator = o.allocator,
+        .alloc = o.allocator,
     });
     defer branch_refs.free(o.allocator);
 

--- a/src/lib/libgit2/branch.zig
+++ b/src/lib/libgit2/branch.zig
@@ -52,6 +52,10 @@ pub const GitBranch = struct {
         }
         return cStringToGitString(c_string);
     }
+
+    pub fn free(self: GitBranch) void {
+        self.ref.free();
+    }
 };
 
 const GitString = @import("types.zig").GitString;


### PR DESCRIPTION
When user try to create a new feature on an empty repository using `sparse feature` command, it was failing because there is no commit on the repo yet. Because we were were using `start_point` (which is main by default) with `git switch -c <new_feature_branch_name> <start_point>` now we fixed the issue by first checking the existence of the `start_point`. If it doesn't exists, then we are not sending a start_point to git switch command. Then by default git uses current branch as starting point.

Closes #32