### PR TITLE
sparse: update all slices when no conflict

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -1,56 +1,52 @@
 # `sparse update` command
+## Merge Detection
+The `isMerged` function in `slice.zig` determines whether the current slice (a Git branch reference) has been merged into another branch (`into`). It uses Git operations to compare commit trees and logs, caching results for efficiency.
 
-We have challenges with PRs merged with merge commit and squash. Squash commits completely invalidates the
-history in a `slice` and creates 1 commit that combines all the commits. So git doesnt really know how to
-create relations between a `slice` and a squashed commit that has all commits in a `slice`. It thinks that
-they are different things.
+### Step-by-Step Breakdown
+1. **Check Cache**
+   If the merge status for the target branch is already cached in `_is_merge_into_map`, return the cached result.
+2. **Quick Object ID Check**
+   If the object IDs (commit hashes) of the two branches are the same, return `false` (no merge check needed).
+3. **Find Merge Base**
+   Use `GitMerge.base` to find the common ancestor commit (merge base) between the current slice and the target branch.
+4. **Get Trees for Comparison**
+   - Use `git rev-parse` to get the tree hash of the merge base.
+   - Use `git rev-parse` to get the tree hash of the current slice.
+5. **Get Commit Trees in Target Branch**
+   Use `git log --format=%T <merge_base>..<into>` to get all tree hashes in the target branch since the merge base.
+6. **Compare Trees**
+   - For each tree hash in the log, compare it to the slice’s tree hash.
+   - If a match is found, the slice is considered merged. Cache and return `true`.
+   - If no match is found, cache and return `false`.
 
-Options to overcome this limitation:
-- We can check all the slices in the feature and check the diff of them with the target branch, after every merge.
-  - if we dont see any diff for one of the slices in the feature then that means that slice is the one recently merged.
-  - Things to consider here: all of the slices may have been merged already for the feature and there might be additional
-  changes in the target branch, which will lead to a diff result for all slices. Similarly if none of the slices has been
-  merged recently this will also cause the same result.
-
-If user uses `rebase` to merge PRs then it is a lot easier to track down what is merged or not. Switching to last slice
-and running `git rebase <target> --update-refs` updates the slices in between as well and then each slice can be pushed
-to its corresponding remote (maybe with `git config branch.<branch-name>.remote` if there is no remote no need to update?).
-
-## Comparing tree diffs to determine if a slice is merged
-- Make sure to fetch all latest update for the target branch
-  - `git fetch origin main` or we can fetch all
-- Find the leaf slice for the feature (using slice graph)
-- Find the commit that leaf slice is originated from `git merge-base origin/main <slice>`, lets call this `BASE_COMMIT` from now on
-- Constructing signature for the slice to compare later
-  - `git merge-base origin/main sparse/talhaHavadar/bbb/slice/1`    >> to find merge base
-  - `git rev-parse 0936548e565e8cb2f418a61f976a0d46344a51eb^{tree}` >> to find tree for the base
-  - `git rev-parse sparse/talhaHavadar/bbb/slice/1^{tree}` >> tree for base
-  -
-  ```
-  git log --format=%T origin/main
-  ecad67691852882849effb28faeba3f2d28dd7aa
-  0c2c47cd29d1e6542aad626705269ba1dfbb5e77
-  a59382a78c21daa47d0f5b035306858aca252eae
-  ```
-  - `git merge-base --is-ancestor $SLICE_TIP origin/main` >> check if it is merged with merge commit
-
-## Algorithm to update
-- Initialization:
-  - `git fetch --all --prune` get the absolute latest state from all remotes (maybe omit prune?).
-  - We already have slices graph for the active feature. So we can use this graph to loop through slices in feature.
-  - Identify the target branch (e.g., main). This can be done by checking the target(recursively until null then ref.createdFrom) of leafNode in slice graph.
-- Merge Detection Loop:
-    - Iterate through your slices from bottom to top (slice-1 to slice-N).
-    - For each slice-k:
-      - First, check the easy way: has it been merged by rebase/merge-commit? The commits of a merged branch will be part of the target branch's history.
-        - we can get the tip of a slice like (`slice.ref` << this points the tip of the slice)
-        - Check if that commit is an ancestor of the target branch `git merge-base --is-ancestor $SLICE_TIP origin/main` If this succeeds, the slice (and all below it) are merged.
-        - Mark them as such and continue to the next slice.
-      - If not, check for a squash merge using the "Comparing Tree Diffs" algorithm described in [Comparing tree diffs](#comparing-tree-diffs-to-determine-if-a-slice-is-merged).
-        - If a squash merge is detected, mark the slice as merged and "re-parent" (`git rebase --onto <new-parent> <old-parent> <branch-to-move>`) the next slice (slice-k+1) to be based on the new origin/main.
-        - If no merge is detected, stop the loop. slice-k is the first unmerged slice.
-- Rebase Remaining Slices:
-  - Once we found the first unmerged slice (slice-k), we know that it and all slices above it (slice-k+1 to slice-N) need to be updated.
-  - Perform the `git rebase --update-refs` routine on the entire remaining stack (slice-k through slice-N).
-    - `git rebase origin/main --onto origin/main $STACK_BASE $STACK_TIP --update-refs`
-    - `git merge-base origin/main <last-slice-in-stack>` << can be useful to find the commit that entire feature began.
+### High-Level Overview
+```mermaid
+graph TD
+    A[Start isMerged] --> B{Is result cached?}
+    B -- Yes --> C[Return cached result]
+    B -- No --> D{Are object IDs equal?}
+    D -- Yes --> E[Return false]
+    D -- No --> F[Find merge base]
+    F --> G[Get tree hash of merge base]
+    G --> H[Get tree hash of slice]
+    H --> I[Get tree hashes in target branch since merge base]
+    I --> J{Any tree hash matches slice tree?}
+    J -- Yes --> K[Cache & Return true]
+    J -- No --> L[Cache & Return false]
+```
+### Git Operations Sequence Diagram
+```mermaid
+sequenceDiagram
+    participant Slice
+    participant Git
+    Slice->>Git: Find merge base (GitMerge.base)
+    Slice->>Git: Get merge base tree (git rev-parse <merge_base>^{tree})
+    Slice->>Git: Get slice tree (git rev-parse <slice_ref>^{tree})
+    Slice->>Git: Get log trees (git log --format=%T <merge_base>..<into>)
+    Slice->>Slice: Compare log trees to slice tree
+    alt Match found
+        Slice->>Slice: Cache & return true
+    else No match
+        Slice->>Slice: Cache & return false
+    end
+```

--- a/src/cli/update_command.zig
+++ b/src/cli/update_command.zig
@@ -11,6 +11,9 @@ const Params = struct {
     _options: struct {
         const Options = @This();
 
+        /// --continue:    continue updating after fixing merge conflicts
+        @"--continue": bool = false,
+
         /// -h, --help:    shows this help message.
         @"--help": *const fn () void = Options.help,
         @"-h": *const fn () void = Options.help,
@@ -51,7 +54,10 @@ pub const UpdateCommand = struct {
         );
         log.debug("parsed update command:: ", .{});
 
-        try Sparse.update(.{ .alloc = alloc });
+        try Sparse.update(.{
+            .alloc = alloc,
+            .@"continue" = params._options.@"--continue",
+        });
 
         return 0;
     }

--- a/src/lib/libgit2/branch.zig
+++ b/src/lib/libgit2/branch.zig
@@ -84,18 +84,7 @@ pub const GitBranch = struct {
     /// branch part of it.
     ///
     pub fn name(self: GitBranch) !GitString {
-        return try GitBranch._name(self._ref);
-    }
-
-    fn _name(ref: GitReference) !GitString {
-        var c_string: [*:0]const u8 = undefined;
-        const res: c_int = c.git_branch_name(@ptrCast(&c_string), ref.value);
-        if (res == c.GIT_EINVALID) {
-            return GitError.GIT_EINVALID;
-        } else if (res != 0) {
-            return GitError.UNEXPECTED_ERROR;
-        }
-        return cStringToGitString(c_string);
+        return try self._ref.branchName();
     }
 
     /// Get the upstream of a branch

--- a/src/lib/libgit2/reference.zig
+++ b/src/lib/libgit2/reference.zig
@@ -198,6 +198,26 @@ pub const GitReference = struct {
         };
     }
 
+    /// Get the name of a branch
+    ///
+    /// Given a reference, this will return a new string object corresponding
+    /// to its name.
+    ///
+    /// https://libgit2.org/docs/reference/main/branch/git_branch_name.html
+    ///
+    /// @param self The branch reference
+    /// @return The name of the branch
+    pub fn branchName(self: GitReference) !GitString {
+        var c_string: [*:0]const u8 = undefined;
+        const res: c_int = c.git_branch_name(@ptrCast(&c_string), self.value);
+        if (res == c.GIT_EINVALID) {
+            return GitError.GIT_EINVALID;
+        } else if (res != 0) {
+            return GitError.UNEXPECTED_ERROR;
+        }
+        return cStringToGitString(c_string);
+    }
+
     /// Get the upstream of a branch
     ///
     /// Given a reference, this will return a new reference object corresponding

--- a/src/lib/sparse.zig
+++ b/src/lib/sparse.zig
@@ -6,6 +6,8 @@ pub const Error = error{
     BACKEND_UNABLE_TO_GET_REFS,
     UNABLE_TO_SWITCH_BRANCHES,
     CORRUPTED_FEATURE,
+    REPARENTING_FAILED,
+    REBASE_IN_PROGRESS,
     UNABLE_TO_DETECT_CURRENT_FEATURE,
     RECOVERABLE_ORPHAN_SLICES_IN_FEATURE,
     RECOVERABLE_FORKED_SLICES_IN_FEATURE,
@@ -189,31 +191,131 @@ pub fn slice(o: struct { slice_name: ?[]const u8 }) !void {
 /// target, ensuring a clean and consistent state within the feature.
 pub fn update(o: struct {
     alloc: std.mem.Allocator,
+    @"continue": bool = false,
 }) !void {
     try LibGit.init();
     defer LibGit.shutdown() catch @panic("Oops: couldn't shutdown libgit2, something weird is cooking...");
+    const repo = try LibGit.GitRepository.open();
+    defer repo.free();
 
-    var current_feature = try Feature.activeFeature(.{ .alloc = o.alloc });
-    defer {
-        if (current_feature) |*f| f.free(o.alloc);
-    }
-    if (current_feature) |cf| {
-        const target = try cf.target(o.alloc);
-        log.debug("update:: current_feature.name:{s} current_feature.target:{s} current_feature.ref_name:{s}", .{
-            cf.name,
-            if (target) |t| t.name() else "null",
-            cf.ref_name,
-        });
-        //try Slice.printSliceGraph(std.io.getStdOut().writer(), cf.slices.?.items);
-        const leaves = try Slice.leafNodes(.{ .alloc = o.alloc, .slice_pool = cf.slices.?.items });
-        defer o.alloc.free(leaves);
-        var ss: ?*Slice = leaves[0];
-        while (ss != null) : (ss = ss.?.target) {
-            _ = try ss.?.isMerged(.{ .alloc = o.alloc, .into = try target.?.upstream(ss.?.repo) });
-        }
+    // Check if a rebase is in progress
+    const is_rebase_in_progress = try Git.isRebaseInProgress(o.alloc, repo);
+    if (is_rebase_in_progress) {
+        log.err("update:: rebase in progress", .{});
+        // TODO: print an informative message about the rebase in progress and
+        // suggest user to fix the conflicts and run `git rebase --continue`
+        // once it is done run `sparse update --continue`
+        return Error.REBASE_IN_PROGRESS;
     } else {
-        log.err("update:: not able to detect current branch", .{});
-        return Error.UNABLE_TO_DETECT_CURRENT_FEATURE;
+        var current_feature = try Feature.activeFeature(.{ .alloc = o.alloc });
+        defer {
+            if (current_feature) |*f| f.free(o.alloc);
+        }
+        if (current_feature) |cf| {
+            const target = try cf.target(o.alloc);
+            log.debug("update:: current_feature.name:{s} current_feature.target:{s} current_feature.ref_name:{s}", .{
+                cf.name,
+                if (target) |t| t.name() else "null",
+                cf.ref_name,
+            });
+            const leaves = try Slice.leafNodes(.{
+                .alloc = o.alloc,
+                .slice_pool = cf.slices.?.items,
+            });
+            defer o.alloc.free(leaves);
+            var ss: ?*Slice = leaves[0];
+            const upstream = try target.?.upstream(ss.?.repo);
+            defer upstream.free();
+
+            var last_unmerged: ?*Slice = ss;
+            while (ss != null) : (ss = ss.?.target) {
+                const is_merged = try ss.?.isMerged(.{
+                    .alloc = o.alloc,
+                    .into = upstream,
+                });
+                if (!is_merged) {
+                    last_unmerged = ss;
+                } else break;
+            }
+            if (last_unmerged) |lu| {
+                log.debug("update:: last_unmerged:{s}", .{lu.ref.name()});
+                // re-parent last_unmerged to target
+                // rebase all slices from tip to target
+                // git rebase --onto <new-parent> <old-parent> <branch-to-move>
+                const old_parent = res: {
+                    if (lu.ref.createdFrom(lu.repo)) |op_ref| {
+                        break :res op_ref.name();
+                    } else {
+                        if (target) |t| {
+                            break :res t.name();
+                        } else {
+                            // TODO: Handle the case when target is null
+                            // At least fall back to default target for sparse in
+                            // git config, maybe something like `sparse.default.target`
+                            break :res "main";
+                        }
+                    }
+                };
+
+                // TODO: save state of the sparse update we need this information
+                // in case there is a conflict or error during the rebase process
+                // so that we can resume the update from where it left off
+
+                try reparent(.{
+                    .alloc = o.alloc,
+                    .tip_slice = leaves[0],
+                    .old_parent = old_parent,
+                    .new_parent = target.?,
+                    .branch_to_move = lu.ref,
+                });
+
+                {
+                    const rr_rebase = try Git.rebase(
+                        .{
+                            .allocator = o.alloc,
+                            .args = &.{
+                                lu.ref.name(),
+                                "--update-refs",
+                            },
+                        },
+                    );
+                    defer o.alloc.free(rr_rebase.stdout);
+                    defer o.alloc.free(rr_rebase.stderr);
+                    log.debug("update:: rebase stdout: {s}", .{rr_rebase.stdout});
+                    if (rr_rebase.term.Exited != 0) {
+                        log.debug("update:: rebase stderr: {s}", .{rr_rebase.stderr});
+                        log.err(
+                            "update:: rebase failed with exit code {d}",
+                            .{rr_rebase.term.Exited},
+                        );
+                        return Error.REPARENTING_FAILED;
+                    }
+                }
+
+                // TODO: cleanup merged slices, loop forward since last_unmerged
+                // is the last unmerged slice
+                // var current = lu;
+                // while (current != null) : (current = current.?.target) {
+                //     if (current.?.isMerged(.{
+                //         .alloc = o.alloc,
+                //         .into = try target.?.upstream(current.?.repo),
+                //     })) {
+                //         current.?.cleanupMergedSlices(o.alloc);
+                //     }
+                // }
+
+            } else {
+                log.debug("update:: no unmerged slices", .{});
+            }
+        } else {
+            if (!o.@"continue") {
+                log.err("update:: not able to detect current branch", .{});
+                return Error.UNABLE_TO_DETECT_CURRENT_FEATURE;
+            }
+            // TODO: implement the continue operation
+            // TODO: check if this is a valid continue operation
+            // we need to check there is already a sparse update in progress
+        }
     }
 }
 
@@ -221,6 +323,60 @@ pub fn submit(opts: struct {}) !void {
     _ = opts;
     std.debug.print("\n===sparse-submit===\n\n", .{});
     std.debug.print("\n====================\n", .{});
+}
+
+fn reparent(o: struct {
+    alloc: std.mem.Allocator,
+    tip_slice: *const Slice,
+    new_parent: GitReference,
+    old_parent: []const u8,
+    branch_to_move: GitReference,
+    continuing: bool = false,
+}) !void {
+    if (!o.continuing) {
+        const rr_rebase = try Git.rebase(.{
+            .allocator = o.alloc,
+            .args = &[_][]const u8{
+                "-r",
+                "--onto",
+                o.new_parent.name(),
+                o.old_parent,
+                o.branch_to_move.name(),
+                "--update-refs",
+            },
+        });
+        defer o.alloc.free(rr_rebase.stderr);
+        defer o.alloc.free(rr_rebase.stdout);
+        log.debug("update:: rebase stdout: {s}", .{rr_rebase.stdout});
+        if (rr_rebase.term.Exited != 0) {
+            log.debug("update:: rebase stderr: {s}", .{rr_rebase.stderr});
+            log.err(
+                "update:: rebase failed during re-parenting with exit code {d}",
+                .{rr_rebase.term.Exited},
+            );
+            // TODO: let user know what to do next
+            return Error.REPARENTING_FAILED;
+        }
+    }
+    // do switching to tip no matter what
+    {
+        const rr_switch = try Git.@"switch"(.{
+            .allocator = o.alloc,
+            .args = &.{
+                try o.tip_slice.ref.branchName(),
+            },
+        });
+        defer o.alloc.free(rr_switch.stdout);
+        defer o.alloc.free(rr_switch.stderr);
+        if (rr_switch.term.Exited != 0) {
+            log.debug("update:: switch stderr: {s}", .{rr_switch.stderr});
+            log.err(
+                "update:: switch failed with exit code {d}",
+                .{rr_switch.term.Exited},
+            );
+            return Error.REPARENTING_FAILED;
+        }
+    }
 }
 
 fn jump(o: struct {
@@ -287,6 +443,7 @@ const constants = @import("constants.zig");
 const LibGit = @import("libgit2/libgit2.zig");
 const GitString = LibGit.GitString;
 const GitBranch = LibGit.GitBranch;
+const GitReference = LibGit.GitReference;
 const GitBranchType = LibGit.GitBranchType;
 const Git = @import("system/Git.zig");
 const Feature = @import("Feature.zig");

--- a/src/lib/system/Git.zig
+++ b/src/lib/system/Git.zig
@@ -305,6 +305,24 @@ pub fn log(o: struct {
     });
 }
 
+pub fn rebase(o: struct {
+    allocator: std.mem.Allocator,
+    args: []const []const u8,
+}) !RunResult {
+    logger.debug("rebase:: args:{s}", .{o.args});
+    const command: []const []const u8 = &.{
+        "git",
+        "rebase",
+    };
+    const argv = try utils.combine([]const u8, o.allocator, command, o.args);
+    defer o.allocator.free(argv);
+
+    return try std.process.Child.run(.{
+        .allocator = o.allocator,
+        .argv = argv,
+    });
+}
+
 const constants = @import("../constants.zig");
 const utils = @import("../utils.zig");
 const SparseError = @import("../sparse.zig").Error;


### PR DESCRIPTION
This commit enables `sparse update` to work properly when there is no
conflict detected during rebase. So for conflict cases to be handled
properly I put some TODOs for future myself.

DO NOT MERGE BEFORE:
* __->__ #47 