### PR TITLE
sparse: fetch before starting update

### DIFF
--- a/src/lib/sparse.zig
+++ b/src/lib/sparse.zig
@@ -215,6 +215,13 @@ pub fn update(o: struct {
         defer {
             if (current_feature) |*f| f.free(o.alloc);
         }
+
+        {
+            const rr_fetch = try Git.fetch(.{ .allocator = o.alloc, .args = &.{} });
+            defer o.alloc.free(rr_fetch.stderr);
+            defer o.alloc.free(rr_fetch.stdout);
+        }
+
         if (current_feature) |*cf| {
             // clean up the state
             try updateGoodWeather(.{ .alloc = o.alloc, .feature = cf, .state = &state });
@@ -325,7 +332,6 @@ fn updateGoodWeather(o: struct {
     feature: *Feature,
     state: *State.Update,
 }) !void {
-    // TODO: run git fetch to update remote branches
     const target = try o.feature.target(o.alloc);
     o.state.free(o.alloc);
     o.state._data.feature = try o.alloc.dupe(u8, o.feature.name);

--- a/src/lib/system/Git.zig
+++ b/src/lib/system/Git.zig
@@ -401,6 +401,24 @@ pub fn @"merge-base"(o: struct {
     });
 }
 
+pub fn fetch(o: struct {
+    allocator: std.mem.Allocator,
+    args: []const []const u8,
+}) !RunResult {
+    logger.debug("fetch:: args:{s}", .{o.args});
+    const command: []const []const u8 = &.{
+        "git",
+        "fetch",
+    };
+    const argv = try utils.combine([]const u8, o.allocator, command, o.args);
+    defer o.allocator.free(argv);
+
+    return try std.process.Child.run(.{
+        .allocator = o.allocator,
+        .argv = argv,
+    });
+}
+
 const constants = @import("../constants.zig");
 const utils = @import("../utils.zig");
 const LibGit = @import("../libgit2/libgit2.zig");


### PR DESCRIPTION
It is best to have remotes fetched before even starting a new update
or continuing one. So for now we are calling `git fetch` directly
before doing any update related task.