### PR TITLE
sparse: add `status` command frontend

### DIFF
--- a/src/cli/command.zig
+++ b/src/cli/command.zig
@@ -28,6 +28,7 @@ pub const Command = union(enum) {
     feature: FeatureCommand,
     slice: SliceCommand,
     update: UpdateCommand,
+    status: StatusCommand,
 
     pub fn run(self: Command, alloc: Allocator) !u8 {
         switch (self) {
@@ -204,3 +205,4 @@ pub fn parsePositionals(
 const FeatureCommand = @import("feature_command.zig").FeatureCommand;
 const SliceCommand = @import("slice_command.zig").SliceCommand;
 const UpdateCommand = @import("update_command.zig").UpdateCommand;
+const StatusCommand = @import("status_command.zig").StatusCommand;

--- a/src/cli/helpgen.zig
+++ b/src/cli/helpgen.zig
@@ -15,6 +15,7 @@ fn genCommands(alloc: std.mem.Allocator, writer: anytype) !void {
     try extractFileIntoHelp(alloc, writer, "feature_command.zig", "sparse_feature");
     try extractFileIntoHelp(alloc, writer, "slice_command.zig", "sparse_slice");
     try extractFileIntoHelp(alloc, writer, "update_command.zig", "sparse_update");
+    try extractFileIntoHelp(alloc, writer, "status_command.zig", "sparse_status");
 }
 
 fn extractFileIntoHelp(alloc: Allocator, writer: anytype, comptime zig_file: []const u8, comptime const_name: []const u8) !void {

--- a/src/cli/status_command.zig
+++ b/src/cli/status_command.zig
@@ -1,0 +1,59 @@
+const std = @import("std");
+const Allocator = @import("std").mem.Allocator;
+const log = @import("std").log.scoped(.feature_command);
+const help_strings = @import("help_strings");
+
+/// sparse status [ options ]
+///
+/// Show status information for current feature
+const Params = struct {
+    /// options:
+    _options: struct {
+        const Options = @This();
+
+        /// -h, --help:    shows this help message.
+        @"--help": *const fn () void = Options.help,
+        @"-h": *const fn () void = Options.help,
+
+        pub fn help() void {
+            std.io.getStdOut().writer().print(help_strings.sparse_status, .{}) catch return;
+        }
+    } = .{},
+};
+
+///
+/// sparse status [ options ]
+///
+pub const StatusCommand = struct {
+    pub fn run(self: StatusCommand, alloc: Allocator) !u8 {
+        _ = self;
+        var params = Params{};
+        const args = try std.process.argsAlloc(alloc);
+        defer std.process.argsFree(alloc, args);
+        log.debug("run:: args: {s}", .{args});
+
+        const cli_positionals = command.parseOptions(
+            @TypeOf(params._options),
+            alloc,
+            &params._options,
+            args,
+        ) catch |err| switch (err) {
+            command.Error.OptionHandledAlready => return 0,
+            else => return err,
+        };
+
+        defer alloc.free(cli_positionals);
+        try command.parsePositionals(
+            Params,
+            alloc,
+            &params,
+            cli_positionals,
+        );
+        log.debug("parsed update command:: ", .{});
+
+        return 0;
+    }
+};
+
+const Sparse = @import("sparse_lib").Sparse;
+const command = @import("command.zig");


### PR DESCRIPTION
This adds frontend for `sparse status` command utilizing existing helpgen feature.