### PR TITLE
sparse: pull the changes from remote to target branch

### DIFF
--- a/src/lib/sparse.zig
+++ b/src/lib/sparse.zig
@@ -334,6 +334,21 @@ fn updateGoodWeather(o: struct {
 }) !void {
     const target = try o.feature.target(o.alloc);
     o.state.free(o.alloc);
+    {
+        const target_branch = try target.?.branchName();
+        const target_branch_refspec = try std.fmt.allocPrint(o.alloc, "{s}:{s}", .{ target_branch, target_branch });
+        defer o.alloc.free(target_branch_refspec);
+        const rr_fetch = try Git.fetch(.{
+            .allocator = o.alloc,
+            .args = &.{
+                // TODO: get the remote from config
+                "origin",
+                target_branch_refspec,
+            },
+        });
+        defer o.alloc.free(rr_fetch.stderr);
+        defer o.alloc.free(rr_fetch.stdout);
+    }
     o.state._data.feature = try o.alloc.dupe(u8, o.feature.name);
     o.state._data.target = if (target) |t| try o.alloc.dupe(u8, t.name()) else null;
     o.state._data.last_operation = .Analyze;


### PR DESCRIPTION
use git fetch origin <target>:<target> to pull changes from remote this makes sure that the target branch in local is also sync with remote