### PR TITLE
sparse: fix feature jump to logically last slice

### DIFF
--- a/src/lib/Feature.zig
+++ b/src/lib/Feature.zig
@@ -201,10 +201,12 @@ pub fn activate(self: *Feature, o: struct {
                 );
             } else {
                 if (slice_array.items.len > 0) {
+                    const leaves = try Slice.leafNodes(.{ .alloc = o.allocator, .slice_pool = slice_array.items });
+                    defer o.allocator.free(leaves);
                     slice_name = try std.fmt.allocPrint(
                         o.allocator,
                         "{s}",
-                        .{slice_array.getLast().ref.name()},
+                        .{leaves[0].ref.name()},
                     );
                 } else {
                     slice_name = try std.fmt.allocPrint(o.allocator, "{s}/slice/1", .{self.ref_name});


### PR DESCRIPTION
`sparse feature` command was jumping to the alphabetically last slice instead of jumping to logically last slice. It is fixed by using slice graph leaves.